### PR TITLE
Disable long_description warnings, enable public method warnings.

### DIFF
--- a/travis/python-lint.sh
+++ b/travis/python-lint.sh
@@ -40,17 +40,18 @@ fi
 echo "   ... Running linters"
 
 # Create prospector configuration file
+#
+# The reasons for disabling the following warnings are as follows:
+# - PYR06: The use of long_description is superceded by using
+#          long_description_markdown_filename from setuptools-markdown
 prospector_config_file="$(mktemp -d /tmp/dir.XXXXXXXX)/.prospector.yml"
 cat >"${prospector_config_file}" <<EOL
 ignore:
   - (^|/)\..+
 
 pylint:
-  disable:
-    - R0904
-    - R0903
-
   options:
+    min-public-methods: 2
     max-locals: 15
     max-returns: 6
     max-branches: 12
@@ -59,6 +60,10 @@ pylint:
     max-attributes: 7
     max-module-lines: 1000
     max-line-length: 79
+
+pyroma:
+  disable:
+    - PYR06
 
 mccabe:
   options:


### PR DESCRIPTION
The minimum required number of public functions was changed to 2.
This is to prevent the proliferation of classes that could better
be expressed as a function closure. Some classes, such as
enums or utility classes which only override internal methods
will still exist - warnings for those can be disabled using
inline suppressions.
