### PR TITLE
Don't install "pandoc" from pip.

### DIFF
--- a/travis/python-install.sh
+++ b/travis/python-install.sh
@@ -46,7 +46,7 @@ setup_pandoc
 echo "=> Installing python project and dependencies"
 
 echo "   ... Installing doc converters (pypandoc, setuptools-markdown)"
-pip install pandoc setuptools-markdown
+pip install setuptools-markdown
 
 echo "   ... Installing project"
 check_status_of python setup.py install


### PR DESCRIPTION
The pandoc package is actually just a broken shell wrapper around
the pandoc tool. setuptools-markdown will automatically import
pypandoc which works much better.
