### PR TITLE
Use symlinks instead of PATH export.

### DIFF
--- a/travis/python-prepare-doc-deploy.sh
+++ b/travis/python-prepare-doc-deploy.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 # /travis/python-prepare-doc-deploy.sh
 #
-# Sets environment variables so that deploys with markdown documentation
-# work correctly. Use with source on before_deploy.
+# Symlinks everything inside ~/.cabal/bin to $VIRTUAL_ENV/bin,
+# which enables the use of pandoc at deploy-time. Environment
+# variables aren't preserved at the deploy step, hence why this
+# approach is needed here.
 #
 # See LICENCE.md for Copyright information
 
-export PATH=${HOME}/.cabal/bin:${PATH}
+for file in ${HOME}/.cabal/bin/* ; do
+    ln -s "${HOME}/.cabal/bin/${file}" "${VIRTUAL_ENV}/bin/"
+done


### PR DESCRIPTION
PATH isn't preserved at the deploy step, so (as a hack) symlink
everything from the .cabal/bin/* path to ${VIRTUAL_ENV}/bin. That way
pandoc will be available.