### PR TITLE
Clean up build artefacts before caching.

### DIFF
--- a/travis/prepare-lang-cache.sh
+++ b/travis/prepare-lang-cache.sh
@@ -2,7 +2,11 @@
 # /travis/prepare-lang-cache.sh
 #
 # Copies locally installed packages into cache path, where they will be
-# restored from later
+# restored from later. Also deletes useless build artefacts which only
+# take up space.
+#
+# As a result, to install more packages, the caches need to be flushed
+# completely first.
 #
 # See LICENCE.md for Copyright information
 
@@ -15,11 +19,15 @@ while getopts "p:l:" opt; do
     esac
 done
 
+echo "=> Preparing for language caching."
+
 LANG_RT_PATH="${path}"
 
 python_dirs="" # shellcheck disable=SC2034
 ruby_dirs="gem" # shellcheck disable=SC2034
 haskell_dirs="ghc cabal" # shellcheck disable=SC2034
+
+echo "   ... Moving local installation directories to cache path."
 
 for lang in ${languages} ; do
     dirs_variable="${lang}_dirs"
@@ -27,3 +35,18 @@ for lang in ${languages} ; do
         mv "${HOME}/.${dir}" "${LANG_RT_PATH}/.${dir}"
     done
 done
+
+echo "    ... Cleaning up haskell artefacts"
+
+if [ -d "${LANG_RT_PATH}/.cabal" ] ; then
+    find "${LANG_RT_PATH}/.cabal/lib" -type f -name "*.a" -print0 |\
+        xargs -0 -L1 rm
+    find "${LANG_RT_PATH}/.cabal/lib" -type f -name "*.o" -print0 |\
+        xargs -0 -L1 rm
+    find "${LANG_RT_PATH}/.cabal/packages" -type f -name "*.tar.gz" -print0 |\
+        xargs -0 -L1 rm
+fi
+
+echo "    ... To install other packages in this container, delete the"\
+    " build cache first."
+

--- a/travis/project-lint.sh
+++ b/travis/project-lint.sh
@@ -6,9 +6,6 @@
 # See LICENCE.md for Copyright information
 
 echo "=> Linting Project"
-echo "   ... Installing requirements"
-gem install mdl > /dev/null 2>&1
-pip install polysquare-generic-file-linter > /dev/null 2>&1
 
 
 while getopts "d:e:x:" opt; do
@@ -53,13 +50,19 @@ function get_extensions_arguments() {
 failures=0
 
 function check_status_of() {
-    output_file=$(mktemp)
-    eval "$@" > "${output_file}" 2>&1
+    output_file=$(mktemp /tmp/tmp.XXXXXXX)
+    concat_cmd=$(echo "$@" | xargs echo)
+    eval "${concat_cmd}" > "${output_file}" 2>&1
     if [[ $? != 0 ]] ; then
         failures=$((failures + 1))
         cat "${output_file}"
+        echo "A subcommand failed. Consider deleting the travis build cache."
     fi
 }
+
+echo "   ... Installing requirements"
+check_status_of gem install mdl
+check_status_of pip install polysquare-generic-file-linter
 
 echo "   ... Linting files for Polysquare style guide"
 get_exclusions_arguments excl_args

--- a/travis/python-install.sh
+++ b/travis/python-install.sh
@@ -17,10 +17,13 @@ while getopts "p" opt; do
 done
 
 function check_status_of() {
+    output_file=$(mktemp /tmp/tmp.XXXXXXX)
     concat_cmd=$(echo "$@" | xargs echo)
-    eval "${concat_cmd}"
+    eval "${concat_cmd}" > "${output_file}" 2>&1
     if [[ $? != 0 ]] ; then
         failures=$((failures + 1))
+        cat "${output_file}"
+        echo "A subcommand failed. Consider deleting the travis build cache."
     fi
 }
 
@@ -28,10 +31,10 @@ function setup_pandoc() {
     if [[ $use_pandoc == 1 ]] ; then
         if which cabal ; then
             echo "=> Installing pandoc"
-            cabal install pandoc
+            check_status_of cabal install pandoc
             echo "   ... Installing doc converters (pypandoc, " \
                 "setuptools-markdown)"
-            pip install setuptools-markdown
+            check_status_of pip install setuptools-markdown
         else
             echo "ERROR: haskell language must be activated. Consider using " \
                      "setup-lang.sh -l haskell to activate it."

--- a/travis/python-lint.sh
+++ b/travis/python-lint.sh
@@ -149,6 +149,7 @@ function check_status_of() {
     if [[ $? != 0 ]] ; then
         failures=$((failures + 1))
         cat "${output_file}"
+        echo "A subcommand failed. Consider deleting the travis build cache."
     fi
 }
 

--- a/travis/setup-lang.sh
+++ b/travis/setup-lang.sh
@@ -74,6 +74,8 @@ function setup_haskell {
 
     ghc-pkg recache > /dev/null
     echo "   ... GHC package cache up to date"
+    echo "   ... Updating cabal repositories"
+    cabal update > /dev/null
     echo "   ... done!"
 }
 
@@ -138,12 +140,6 @@ else
             mv "${LANG_RT_PATH}/.${dir}" "${HOME}/.${dir}"
         done
     done
-fi
-
-# Update package repositories (we should do this on every run)
-echo "=> Updating scripting language repositories"
-if which cabal ; then
-    cabal update > /dev/null
 fi
 
 # Activate languages

--- a/travis/shell-lint.sh
+++ b/travis/shell-lint.sh
@@ -6,9 +6,6 @@
 # See LICENCE.md for Copyright information
 
 echo "=> Linting Shell Files"
-echo "   ... Installing requirements"
-cabal install shellcheck > /dev/null 2>&1
-pip install bashlint > /dev/null 2>&1
 
 while getopts "d:x:" opt; do
     case "$opt" in
@@ -39,13 +36,19 @@ function get_exclusions_arguments() {
 failures=0
 
 function check_status_of() {
-    output_file=$(mktemp)
-    eval "$@" > "${output_file}" 2>&1
+    output_file=$(mktemp /tmp/tmp.XXXXXXX)
+    concat_cmd=$(echo "$@" | xargs echo)
+    eval "${concat_cmd}" > "${output_file}" 2>&1
     if [[ $? != 0 ]] ; then
         failures=$((failures + 1))
         cat "${output_file}"
+        echo "A subcommand failed. Consider deleting the travis build cache."
     fi
 }
+
+echo "   ... Installing requirements"
+check_status_of cabal install shellcheck
+check_status_of pip install bashlint
 
 echo "   ... Linting files"
 get_exclusions_arguments excl_args


### PR DESCRIPTION
If newer builds have to install newer packages then those
installations will likely fail. Inform the user that the best
solution is just to delete the travis build cache (we're trading
a fairly massive amount of space for some extra time in the new
installation case).