### PR TITLE
Make sure pandoc is available when installing linters.

### DIFF
--- a/travis/project-lint.sh
+++ b/travis/project-lint.sh
@@ -72,6 +72,12 @@ function check_status_of() {
     fi
 }
 
+# Put .cabal/bin in PATH so that pandoc is available when
+# installing polysquare-generic-file-linter. If pypandoc
+# is installed but pandoc isn't available, then the installer
+# will error out.
+export PATH=${HOME}/.cabal/bin:${PATH}
+
 printf "\n   ... Installing requirements "
 check_status_of gem install mdl
 check_status_of pip install polysquare-generic-file-linter

--- a/travis/python-tests.sh
+++ b/travis/python-tests.sh
@@ -30,7 +30,7 @@ function check_status_of() {
     fi
 }
 
-# Put .cabal/bin in PATH so that pandoc is availalbe when
+# Put .cabal/bin in PATH so that pandoc is available when
 # running test through setup.py
 export PATH=${HOME}/.cabal/bin:${PATH}
 check_status_of coverage run "--source=${module}" setup.py test


### PR DESCRIPTION
If pypandoc got installed and pandoc isn't available, it errors out.