### PR TITLE
Don't write coverage file relative to PWD, but build_directory.

### DIFF
--- a/travis/cmake-tests.sh
+++ b/travis/cmake-tests.sh
@@ -29,7 +29,7 @@ ${src_directory}
 --warn-uninitialized
 \\\"-G${CMAKE_GENERATOR}\\\"
 -DCMAKE_UNIT_LOG_COVERAGE=1
--DCMAKE_UNIT_COVERAGE_FILE=\"${PWD}/tests/build/coverage.trace\"
+-DCMAKE_UNIT_COVERAGE_FILE=\"${build_directory}/coverage.trace\"
 "
 
 build_cmd="cmake --build ${build_directory}"


### PR DESCRIPTION
PWD changes just beforehand. We store the build directory so use
that as it will always be correct.