### PR TITLE
Add tests for util.sh using BATS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ before_install:
  - export __POLYSQUARE_CI_SCRIPTS_BOOTSTRAP="${CONTAINER_DIR}/_scripts/bootstrap.sh"
  - eval "$(bash ~/container/_scripts/setup/shell/setup.sh)"
 script:
- - polysquare_fetch_and_exec check/shell/check.sh -d travis
+ - polysquare_fetch_and_exec check/shell/check.sh -d travis -d tests
  - bash travis/prepare-lang-cache.sh -d ~/container -l haskell -l python -l ruby -l node

--- a/tests/polysquare_ci_scripts_helper.bash
+++ b/tests/polysquare_ci_scripts_helper.bash
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# /tests/polysquare_ci_scripts_helper.bash
+#
+# Loader script for bats which sets the POLYSQUARE_TRAVIS_SCRIPTS
+# environment variable for use with tests.
+#
+# See LICENCE.md for Copyright information
+
+export POLYSQUARE_TRAVIS_SCRIPTS="${BATS_TEST_DIRNAME}/../travis/"
+export _POLYSQUARE_DONT_PRINT_DOTS=1
+export POLYSQUARE_HOST="127.0.0.1:8080"
+
+function print_returned_args_on_newlines {
+    local function_name="$1"
+    local n_args="$2"
+
+    local arguments_to_pass=${*:3}
+    local arguments_to_check=(${*:3:$n_args})
+
+    eval "${function_name} ${arguments_to_pass}" > /dev/null 2>&1
+
+    for index in "${!arguments_to_check[@]}" ; do
+        local argument_name="${arguments_to_check[$index]}"
+        eval "local argument_value=\$$argument_name"
+        echo "${argument_value}"
+    done
+}

--- a/tests/util-fetch.bats
+++ b/tests/util-fetch.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+# /tests/util.bats
+#
+# Tests for the utility functions to fetch shell scripts in travis/
+#
+# See LICENCE.md for Copyright information
+
+load polysquare_ci_scripts_helper
+source "${POLYSQUARE_TRAVIS_SCRIPTS}/util.sh"
+
+setup() {
+    export server_dir=$(mktemp -d /tmp/psq-container.XXXXXX)
+    mkdir -p "${server_dir}" > /dev/null 2>&1
+    pushd "${server_dir}" > /dev/null 2>&1
+    touch "fetch-local-test.sh"
+    python -m "SimpleHTTPServer" 8080 > /dev/null 2>&1 &
+    export __polysquare_fake_host_pid=$!
+    popd > /dev/null 2>&1
+
+    export POLYSQUARE_CI_SCRIPTS_DIR=$(mktemp -d /tmp/psq-container.XXXXXX)
+    mkdir -p "${POLYSQUARE_CI_SCRIPTS_DIR}" > /dev/null 2>&1
+}
+
+teardown() {
+    kill "${__polysquare_fake_host_pid}"
+    rm -rf "${server_dir}" "${POLYSQUARE_CI_SCRIPTS_DIR}" > /dev/null 2>&1
+}
+
+@test "Fetch local file and get path in return value" {
+    local expected_path="${POLYSQUARE_CI_SCRIPTS_DIR}/fetch-local-test.sh"
+
+    polysquare_fetch_and_get_local_file local_path "fetch-local-test.sh"
+
+    [ "${expected_path}" = "${local_path}" ]
+}
+
+@test "Fetch local file and source it" {
+    local server_side_file="${server_dir}/fetch-local-test.sh"
+    echo "server_side_file_variable=1" > "${server_side_file}"
+    polysquare_fetch_and_source "fetch-local-test.sh"
+
+    [ "${server_side_file_variable}" = "1" ]
+}
+
+@test "Fetch local file and source it with arguments" {
+    local server_side_file="${server_dir}/fetch-local-test.sh"
+    echo "server_side_file_variable=\$1" > "${server_side_file}"
+    polysquare_fetch_and_source "fetch-local-test.sh" "argument"
+
+    [ "${server_side_file_variable}" = "argument" ]
+}
+
+@test "Fetch local file and evaluate its output upon running it" {
+    local server_side_file="${server_dir}/fetch-local-test.sh"
+    echo "echo \"server_side_file_variable=1\"" > "${server_side_file}"
+    polysquare_fetch_and_eval "fetch-local-test.sh"
+
+    [ "${server_side_file_variable}" = "1" ]
+}
+
+@test "Fetch local file and evaluate its output upon running it with args" {
+    local server_side_file="${server_dir}/fetch-local-test.sh"
+    echo "echo \"server_side_file_variable=\$1\"" > "${server_side_file}"
+    polysquare_fetch_and_eval "fetch-local-test.sh" "argument"
+
+    [ "${server_side_file_variable}" = "argument" ]
+}
+
+@test "Fetch local file and 'forward' its output" {
+    local server_side_file="${server_dir}/fetch-local-test.sh"
+    echo "echo server_side_file_variable=1" > "${server_side_file}"
+    output=$(polysquare_fetch_and_fwd "fetch-local-test.sh")
+
+    [ "${output}" = "server_side_file_variable=1" ]
+}
+
+@test "Fetch local file and execute it - don't propagate variables" {
+    local server_side_file="${server_dir}/fetch-local-test.sh"
+    echo "echo server_side_file_variable=1" > "${server_side_file}"
+    polysquare_fetch_and_exec "fetch-local-test.sh"
+
+    [ "${server_side_file_variable}" != "1" ]
+}
+

--- a/tests/util.bats
+++ b/tests/util.bats
@@ -1,6 +1,148 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bats
 # /tests/util.bats
 #
 # Tests for the utility functions in travis/
 #
 # See LICENCE.md for Copyright information
+
+load polysquare_ci_scripts_helper
+source "${POLYSQUARE_TRAVIS_SCRIPTS}/util.sh"
+
+@test "Calling print task expands arguments" {
+    run polysquare_print_task arg1 arg2 arg3
+    [ "${lines[0]}" = "=> arg1 arg2 arg3" ]
+}
+
+@test "Calling print task uses single string" {
+    run polysquare_print_task "arg1 arg2 arg3"
+    [ "${lines[0]}" = "=> arg1 arg2 arg3" ]
+}
+
+@test "Calling print status prints dots then args" {
+    run polysquare_print_status "arg1 arg2 arg3"
+    [ "${lines[0]}" = "   ... arg1 arg2 arg3" ]
+}
+
+@test "Calling print error prints bangs then args" {
+    run polysquare_print_error "arg1 arg2 arg3"
+    [ "${lines[0]}" = "   !!! arg1 arg2 arg3" ]
+}
+
+@test "Repeat switch for list" {
+    polysquare_repeat_switch_for_list rval "-x" one two three
+    [ "${rval}" = "-x one two three" ]
+}
+
+@test "Single find extension argument" {
+    polysquare_get_find_extensions_arguments rval sh
+    [ "${rval}" = " -name \"*.sh\"" ]
+}
+
+@test "Monitoring command status with true return value" {
+    run print_returned_args_on_newlines \
+        polysquare_monitor_command_status \
+        1 \
+        rval \
+        true
+    [ "${lines[0]}" = "0" ]
+}
+
+@test "Monitoring command status with false return value" {
+    run print_returned_args_on_newlines \
+        polysquare_monitor_command_status \
+        1 \
+        rval \
+        false
+
+    [ "${lines[0]}" = "1" ]
+}
+
+@test "Monitoring command output to standard output" {
+    run print_returned_args_on_newlines \
+        polysquare_monitor_command_output \
+        2 \
+        command_status \
+        command_output \
+        echo stdout
+
+    command_output=$(cat "${lines[1]}")
+
+    [ "${command_output}" = "stdout" ]
+}
+
+@test "Command with status printed when reporting failures and continuing" {
+    run polysquare_report_failures_and_continue \
+        command_status \
+        false
+
+    [ "${lines[0]}" = "   !!! Subcommand false failed with 1" ]
+}
+
+@test "Successful status returned when reporting failures and continuing" {
+    run print_returned_args_on_newlines \
+        polysquare_report_failures_and_continue \
+        1 \
+        command_status \
+        true
+
+    command_status="${lines[0]}"
+
+    [ "${command_status}" = "0" ]
+}
+
+@test "Fail status returned when reporting failures and continuing" {
+    run print_returned_args_on_newlines \
+        polysquare_report_failures_and_continue \
+        1 \
+        command_status \
+        false
+
+    command_status="${lines[0]}"
+
+    [ "${command_status}" = "1" ]
+}
+
+@test "Successful status returned when noting failures and continuing" {
+    run print_returned_args_on_newlines \
+        polysquare_note_failure_and_continue \
+        1 \
+        command_status \
+        true
+
+    command_status="${lines[0]}"
+
+    [ "${command_status}" = "0" ]
+}
+
+@test "Fail status returned when noting failures and continuing" {
+    run print_returned_args_on_newlines \
+        polysquare_note_failure_and_continue \
+        1 \
+        command_status \
+        false
+
+    command_status="${lines[0]}"
+
+    [ "${command_status}" = "1" ]
+}
+
+@test "Exit with fatal error when reporting a failure" {
+    run polysquare_fatal_error_on_failure \
+        false
+
+    [ "${status}" = "1" ]
+}
+
+@test "Exit with success when no fatal errors to be reported" {
+    polysquare_fatal_error_on_failure true
+    polysquare_fatal_error_on_failure true
+}
+
+@test "Show failing subcommand and status when exiting on fatal error" {
+    run polysquare_fatal_error_on_failure \
+        false
+
+    [ "${lines[0]}" = "   !!! Subcommand false failed with 1" ]
+}
+
+

--- a/travis/check/shell/check.sh
+++ b/travis/check/shell/check.sh
@@ -32,6 +32,7 @@ polysquare_note_failure_and_continue status bash \
     "${POLYSQUARE_CI_SCRIPTS_DIR}/check/shell/lint.sh" \
     "$excl_switches" \
     "$dir_switches"
+
 polysquare_note_failure_and_continue status bash \
     "${POLYSQUARE_CI_SCRIPTS_DIR}/check/shell/test.sh"
 

--- a/travis/check/shell/lint.sh
+++ b/travis/check/shell/lint.sh
@@ -11,6 +11,7 @@ source "${POLYSQUARE_CI_SCRIPTS_DIR}/util.sh"
 function polysquare_check_files_with {
     polysquare_print_status "Linting files with $1"
     for file in ${*:2} ; do
+        polysquare_print_status "Linting ${file}"
         polysquare_report_failures_and_continue exit_status "$1" "${file}"
     done
 }
@@ -32,7 +33,7 @@ for directory in ${directories} ; do
     shell_files+=$(eval "${cmd}")
 done
 
-polysquare_print_task "Linting bash files"
+polysquare_print_task "Linting bash files ${shell_files}"
 
 polysquare_check_files_with shellcheck "${shell_files}"
 polysquare_check_files_with bashlint "${shell_files}"

--- a/travis/check/shell/test.sh
+++ b/travis/check/shell/test.sh
@@ -8,9 +8,16 @@
 
 source "${POLYSQUARE_CI_SCRIPTS_DIR}/util.sh"
 
-polysquare_print_task "Testing bash files $(pwd)"
+polysquare_print_task "Testing bash files"
 
-tests=$(find tests -type f -name \".bats\")
+cmd="find tests -type f -name \"*.bats\""
+tests=$(eval "${cmd}")
 for test in ${tests} ; do
     polysquare_print_status "Running tests in ${test}"
+    printf "\n"
+    polysquare_note_failure_and_continue status bats "${test}"
 done
+
+polysquare_task_completed
+
+polysquare_exit_with_failure_on_script_failures

--- a/travis/util.sh
+++ b/travis/util.sh
@@ -10,8 +10,9 @@
 #
 # See LICENCE.md for Copyright information
 
-export POLYSQUARE_SETUP_SCRIPTS="public-travis-scripts.polysquare.org/setup";
-export POLYSQUARE_CHECK_SCRIPTS="public-travis-scripts.polysquare.org/check";
+export POLYSQUARE_HOST="${POLYSQUARE_HOST-public-travis-scripts.polysquare.org}"
+export POLYSQUARE_SETUP_SCRIPTS="${POLYSQUARE_HOST}/setup";
+export POLYSQUARE_CHECK_SCRIPTS="${POLYSQUARE_HOST}/check";
 
 function polysquare_print_task {
     >&2 printf "\n=> %s" "$*"
@@ -41,16 +42,22 @@ function _polysquare_monitor_command_internal_prologue {
 
     # This is effectively a tool to feed the travis-ci script
     # watchdog. Print a dot every sixty seconds.
-    echo "while :; sleep 60; do printf '.'; done" | bash 2> /dev/null 1>&2 &
-    local printer_pid=$!
+    if [ -z "${_POLYSQUARE_DONT_PRINT_DOTS}" ] ; then
+        echo "while :; sleep 60; do printf '.'; done" | bash 2> /dev/null 1>&2 &
+        local printer_pid=$!
+    else
+        local printer_pid=0
+    fi
 
     eval "${printer_pid_return}='${printer_pid}'"
 }
 
 function _polysquare_monitor_command_internal_epilogue {
     local printer_pid="$1"
-    kill "${printer_pid}" > /dev/null 2>&1
-    wait "${printer_pid}" > /dev/null 2>&1
+
+    if [ -z "${_POLYSQUARE_DONT_PRINT_DOTS}" ] ; then
+        kill -9 "${printer_pid}" > /dev/null 2>&1
+    fi
 }
 
 function polysquare_monitor_command_status {
@@ -155,7 +162,7 @@ function polysquare_get_find_extensions_arguments {
         cmd_append="${cmd_append} -name \"*.${extensions_to_search[$index]}\""
         if [ "$last_element_index" -gt "$index" ] ; then
             cmd_append="${cmd_append} -o"
-        fi 
+        fi
     done
 
     eval "${result}='${cmd_append}'"
@@ -164,10 +171,16 @@ function polysquare_get_find_extensions_arguments {
 function polysquare_repeat_switch_for_list {
     local result=$1
     local switch=$2
+    local list_items_to_repeat_switch_for=${*:3}
+    local last_element_index=$((${#list_items_to_repeat_switch_for[@]} - 1))
     local list_with_repeated_switch=""
 
-    for item in ${*:3} ; do
-        list_with_repeated_switch+="${switch} ${item} "
+    for index in "${!list_items_to_repeat_switch_for[@]}" ; do
+        local item="${list_items_to_repeat_switch_for[$index]}"
+        list_with_repeated_switch+="${switch} ${item}"
+        if [ "$last_element_index" -gt "$index" ] ; then
+            list_with_repeated_switch="${list_with_repeated_switch} "
+        fi
     done
 
     eval "${result}='${list_with_repeated_switch}'"
@@ -175,15 +188,15 @@ function polysquare_repeat_switch_for_list {
 
 function polysquare_fetch_and_get_local_file {
     result=$1
-    local url="public-travis-scripts.polysquare.org/$2"
+    local url="${POLYSQUARE_HOST}/$2"
     local domain="$(echo "${url}" | cut -d/ -f1)"
     local path="${url#$domain}"
-    local output_file="${POLYSQUARE_CI_SCRIPTS_DIR}/${path}"
+    local output_file="${POLYSQUARE_CI_SCRIPTS_DIR}/${path:1}"
 
     # Only download if we don't have the script already. This means
     # that if a project wants a newer script, it has to clear its caches.
     if ! [ -f "${output_file}" ] ; then
-        curl -LSs "${url}" --create-dirs -O "${output_file}"
+        curl -LSs "${url}" --create-dirs -o "${output_file}"
     fi
 
     eval "${result}='${output_file}'"
@@ -202,7 +215,7 @@ function polysquare_fetch_and_source {
 function polysquare_fetch_and_eval {
     local fetched_file=""
     polysquare_fetch_and_get_local_file fetched_file "$1"
-    eval "$(source ${fetched_file} "${@:2}")"
+    eval "$(bash ${fetched_file} "${@:2}")"
 }
 
 function polysquare_fetch_and_fwd {


### PR DESCRIPTION
The tests are run by invoking "bats" on a file ending in ".bats".
These files will use the special BATS "load" command to load
tests/polysquare_ci_scripts_helper.bash.

The tests at present test most of the shared functionality
contained in util.sh, including the monitoring of commands and
reporting of failures. They also include the utility functions
to forward arguments.

In util-fetch.bats, a special fixture is used to start a webserver
which will serve a simple bash file. This is used to test the
polysquare_fetch_and_* family of functions.