### PR TITLE
Reset mtime on easy-install stamps.

### DIFF
--- a/tests/python-check.bats
+++ b/tests/python-check.bats
@@ -113,8 +113,8 @@ teardown() {
     run bash "${POLYSQUARE_TRAVIS_SCRIPTS}/check/python/test.sh" -m example
 
     [[ "${status}" == "0" ]]
-    [[ "${lines[13]}" == "    test_simple_case (tests.unit_test.TestUnit)" ]]
-    [[ "${lines[14]}" == \
+    [[ "${lines[11]}" == "    test_simple_case (tests.unit_test.TestUnit)" ]]
+    [[ "${lines[12]}" == \
        "    tests.unit_test.TestUnit.test_simple_case ... ok" ]]
 }
 

--- a/tests/python-check.bats
+++ b/tests/python-check.bats
@@ -32,8 +32,6 @@ teardown() {
 
     run bash "${POLYSQUARE_TRAVIS_SCRIPTS}/check/python/lint.sh"
 
-    echo "OUTPUT OF THE LINT SCRIPT IS AS FOLLOWS: ${output}"
-
     [[ "${status}" == "1" ]]
     [[ "${lines[5]}" == "        example/example.py:" ]]
     [[ "${lines[6]}" == "            L7:80 None: pep8 - E501" ]]
@@ -51,8 +49,6 @@ teardown() {
 
     run bash "${POLYSQUARE_TRAVIS_SCRIPTS}/check/python/lint.sh"
 
-    echo "OUTPUT OF THE LINT SCRIPT IS AS FOLLOWS: ${output}"
-
     [[ "${status}" == "3" ]]
     [[ "${lines[5]}" == "        tests/unit_test.py:" ]]
     [[ "${lines[6]}" == "            L18:80 None: pep8 - E501" ]]
@@ -65,8 +61,6 @@ teardown() {
         "${_POLYSQUARE_TEST_PROJECT}/example/example.py"
 
     run bash "${POLYSQUARE_TRAVIS_SCRIPTS}/check/python/lint.sh"
-
-    echo "OUTPUT OF THE LINT SCRIPT IS AS FOLLOWS: ${output}"
 
     [[ "${status}" == "3" ]]
 }
@@ -83,8 +77,6 @@ teardown() {
     } >> "${bug_file}"
 
     run bash "${POLYSQUARE_TRAVIS_SCRIPTS}/check/python/lint.sh"
-
-    echo "OUTPUT OF THE LINT SCRIPT IS AS FOLLOWS: ${output}"
 
     local int_div_warning=("        example/example.py:10:" \
                            "Using integer division (1 / 3) may return" \
@@ -105,8 +97,6 @@ teardown() {
 
     run bash "${POLYSQUARE_TRAVIS_SCRIPTS}/check/python/lint.sh"
 
-    echo "OUTPUT OF THE LINT SCRIPT IS AS FOLLOWS: ${output}"
-
     [[ "${status}" == "1" ]]
     [[ "${lines[6]}" == "        example/example.py:" ]]
     [[ "${lines[7]}" == "            L9:- None: vulture - unused-function" ]]
@@ -116,15 +106,11 @@ teardown() {
 @test "Success on no bugs found" {
     run bash "${POLYSQUARE_TRAVIS_SCRIPTS}/check/python/lint.sh"
 
-    echo "OUTPUT OF THE LINT SCRIPT IS AS FOLLOWS: ${output}"
-
     [[ "${status}" == "0" ]]
 }
 
 @test "Run unit tests" {
     run bash "${POLYSQUARE_TRAVIS_SCRIPTS}/check/python/test.sh" -m example
-
-    echo "OUTPUT OF THE LINT SCRIPT IS AS FOLLOWS: ${output}"
 
     [[ "${status}" == "0" ]]
     [[ "${lines[13]}" == "    test_simple_case (tests.unit_test.TestUnit)" ]]

--- a/tests/util-python.bats
+++ b/tests/util-python.bats
@@ -15,6 +15,13 @@ source "${POLYSQUARE_TRAVIS_SCRIPTS}/python-util.sh"
     [[ "${python_version}" =~ ^[1-9]\.[1-9]$ ]]
 }
 
+@test "Get python version at minor" {
+    local python_version
+    polysquare_get_python_version_at_minor python_version
+
+    [[ "${python_version}" =~ ^[1-9]\.[1-9]$ ]]
+}
+
 @test "Run command if python module unavailable" {
     run polysquare_run_if_python_module_unavailable __unavailable echo "true"
 

--- a/travis/deploy/project/deploy.sh
+++ b/travis/deploy/project/deploy.sh
@@ -113,9 +113,12 @@ function polysquare_prepare_caches {
     polysquare_task "Copying language installations to container" \
         polysquare_fatal_error_on_failure \
             polysquare_copy_installation_dirs_to_cache_container
-
     polysquare_task "Cleaning up temporary build files" \
         polysquare_cleanup_build_artefacts
+    polysquare_task "Cleaning up cached CI scripts" \
+        polysquare_fatal_error_on_failure rm -rf "${CONTAINER_DIR}/_scripts"
+    polysquare_task "Cleaning up per-test caches" \
+        polysquare_fatal_error_on_failure rm -rf "${CONTAINER_DIR}/_cache"
 }
 
 polysquare_task "Preparing container for caching" \

--- a/travis/python-util.sh
+++ b/travis/python-util.sh
@@ -13,6 +13,14 @@ function polysquare_get_python_version {
     eval "${python_version_variable}='${_python_version}'"
 }
 
+function polysquare_get_python_version_at_minor {
+    polysquare_get_python_version full_python_version
+    local python_version_at_minor_variable="$1"
+    local _python_version_at_minor="${full_python_version:0:3}"
+
+    eval "${python_version_at_minor_variable}='${_python_version_at_minor}'"
+}
+
 function polysquare_python_is_pypy {
     local is_pypy_variable="$1"
     python --version 2>&1 | grep PyPy > /dev/null

--- a/travis/python-util.sh
+++ b/travis/python-util.sh
@@ -37,10 +37,10 @@ function polysquare_pip_install {
 function polysquare_pip_install_deps {
     local deps="$1"
 
-    if ! [ -f "${CONTAINER_DIR}/_languages/python/.installed-${deps}" ] ; then
+    #if ! [ -f "${CONTAINER_DIR}/_languages/python/.installed-${deps}" ] ; then
         polysquare_pip_install -e ".[${deps}]" \
             --process-dependency-links
         mkdir -p "${CONTAINER_DIR}/_languages/python"
         touch "${CONTAINER_DIR}/_languages/python/.installed-${deps}"
-    fi
+    #fi
 }

--- a/travis/setup/project/haskell_setup.sh
+++ b/travis/setup/project/haskell_setup.sh
@@ -95,9 +95,6 @@ function polysquare_setup_haskell {
             -execdir rm -rf {} \; 2>/dev/null
         find "${hs_ver_cont}" -type f -name "*_l-ghc${haskell_version}.so" \
             -execdir rm -rf {} \; 2>/dev/null
-        find "${hs_ver_cont}" -type f -name "*.so" \
-            ! -path "${hs_ver_cont}/ghc/lib/ghc-${haskell_version}/*" \
-                -execdir rm -rf {} \; 2>/dev/null
 
         # Profiling, debug, other libraries
         find "${hs_ver_cont}" -type f -name "lib*_p.a" -execdir rm -rf {} \; \
@@ -113,6 +110,11 @@ function polysquare_setup_haskell {
 
         # Documentation (~100Mb)
         polysquare_fatal_error_on_failure rm -rf "${hs_ver_cont}/ghc/share/doc"
+        
+        # Logs and other temporary files
+        polysquare_fatal_error_on_failure rm -rf \
+            "${haskell_build_dir}/tmp"
+        polysquare_fatal_error_on_failure rm -rf "${hs_ver_cont}/hsenv.log"
         
         # Disable library-profiling and documentation building
         echo "${cabal_config_append}" >> "${hs_ver_cont}/cabal/config"

--- a/travis/setup/python/setup.sh
+++ b/travis/setup/python/setup.sh
@@ -95,7 +95,7 @@ function polysquare_install_python_dependencies {
     polysquare_task "Installing setup dependencies" \
         polysquare_install_python_setup_dependencies
     polysquare_task "Installing test dependencies" \
-        polysquare_note_failure_and_continue status \
+        polysquare_fatal_error_on_failure \
             polysquare_pip_install_deps test
     polysquare_task "Installing coverage tools" \
         polysquare_fatal_error_on_failure \


### PR DESCRIPTION
This ensures that we don't end up re-uploading the cache.