### PR TITLE
Don't assume that result.coverage_exclude is always a list.

### DIFF
--- a/ciscripts/check/python/check.py
+++ b/ciscripts/check/python/check.py
@@ -83,6 +83,7 @@ def run(cont, util, shell, argv=None):
             assert os.path.exists(tests_dir)
 
             packages = find_packages(exclude=["test"], )
+            coverage_exclude = result.coverage_exclude or list()
 
             with util.in_dir(tests_dir):
                 util.execute(cont,
@@ -90,7 +91,7 @@ def run(cont, util, shell, argv=None):
                              "coverage",
                              "run",
                              "--source=" + ",".join(packages),
-                             "--omit=" + ",".join(result.coverage_exclude),
+                             "--omit=" + ",".join(coverage_exclude),
                              os.path.join(cwd, "setup.py"),
                              "green")
 


### PR DESCRIPTION
If the --coverage-exclude option wasn't passed, then it will
be None. Handle this case by ensuring that we always call
str.join with a list.