### PR TITLE
Explicitly set retrycount to zero when download completes.

### DIFF
--- a/ciscripts/bootstrap.py
+++ b/ciscripts/bootstrap.py
@@ -316,6 +316,7 @@ def _fetch_script(info,
                     contents = urlopen("http://{0}".format(remote)).read()
                     scr.write(contents.decode())
                     scr.truncate()
+                    retrycount = 0
                 except URLError:
                     retrycount -= 1
 


### PR DESCRIPTION
Previously, we were not setting retrycount to zero which meant
that the script would just be repeatededly downloaded.