### PR TITLE
Place standard error at the end of the output.

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -287,6 +287,21 @@ class TestExecute(TestCase):
                                        doctest.ELLIPSIS |
                                        doctest.NORMALIZE_WHITESPACE))
 
+    def test_running_stderr_at_end(self):
+        """Execute a command with success, but display stderr at end."""
+        captured_output = testutil.CapturedOutput()
+        with captured_output:
+            util.execute(Mock(),
+                         util.running_output,
+                         "python",
+                         "-c",
+                         "import sys; "
+                         "sys.stdout.write(\"a\\nb\"); "
+                         "sys.stderr.write(\"c\"); "
+                         "sys.stdout.write(\"d\\n\")")
+
+        self.assertEqual(captured_output.stderr, "\na\nbd\nc\n")
+
     def test_running_output_no_double_leading_slash_n(self):
         """Using running_output does not allow double-leading slash-n."""
         captured_output = testutil.CapturedOutput()


### PR DESCRIPTION
This prevents interleaving between single characters in the
two streams, which is particularly a problem when reading
test error messages.