### PR TITLE
Work around utf-8 decoding errors in pypy3's coverage module.

### DIFF
--- a/ciscripts/util.py
+++ b/ciscripts/util.py
@@ -369,8 +369,7 @@ def execute(container, output_strategy, *args, **kwargs):
     try:
         process = subprocess.Popen(args,
                                    stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE,
-                                   env=env)
+                                   stderr=subprocess.PIPE)
     except OSError as error:
         raise Exception(u"Failed to execute {0} - {1}".format(" ".join(args),
                                                               str(error)))

--- a/test/utf8_print_cmd.txt
+++ b/test/utf8_print_cmd.txt
@@ -1,0 +1,3 @@
+import sys
+sys.stdout.write(u"\N{check mark}")
+sys.exit(1)


### PR DESCRIPTION
If pypy3 sees a utf-8 character being parsed in <string> it fails
to decode it. Place the relevant python command in its own file
and invoke it from the tests.