### PR TITLE
Pass environment variables to subprocess when using util.execute

### DIFF
--- a/DICTIONARY
+++ b/DICTIONARY
@@ -49,6 +49,8 @@ prepends
 pychecker
 pyflakes
 pylint
+pypy
+pypy3
 python
 rootfs
 runtime

--- a/ciscripts/util.py
+++ b/ciscripts/util.py
@@ -369,7 +369,8 @@ def execute(container, output_strategy, *args, **kwargs):
     try:
         process = subprocess.Popen(args,
                                    stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE)
+                                   stderr=subprocess.PIPE,
+                                   env=env)
     except OSError as error:
         raise Exception(u"Failed to execute {0} - {1}".format(" ".join(args),
                                                               str(error)))

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -262,6 +262,22 @@ class TestExecute(TestCase):
                                           util.output_on_fail,
                                           "false"))
 
+    def test_execute_passes_environment_variables(self):
+        """Pass specified environment variables to subprocess."""
+        captured_output = testutil.CapturedOutput()
+        with captured_output:
+            util.execute(Mock(),
+                         util.running_output,
+                         "python",
+                         "-c",
+                         "import os; print(os.environ['KEY'])",
+                         env={"KEY": "VALUE"})
+
+        self.assertThat(captured_output.stderr,
+                        DocTestMatches("...VALUE...",
+                                       doctest.ELLIPSIS |
+                                       doctest.NORMALIZE_WHITESPACE))
+
     # suppress(no-self-use)
     def test_instant_failure_calls_through_to_container(self):
         """Execute a command with failure."""


### PR DESCRIPTION
This was removed in the last change set by accident, added
a test to make sure the functionality works correctly in the future.