### PR TITLE
Link pandoc into first writable directory in PATH on Travis.

### DIFF
--- a/ciscripts/deploy/python/deploy.py
+++ b/ciscripts/deploy/python/deploy.py
@@ -4,16 +4,31 @@
 # because we need to have pandoc available in our PATH.
 #
 # See /LICENCE.md for Copyright information
-"""Activate haskell container in preparation for deployment."""
+"""Place a symbolic link of pandoc in a writable directory in PATH."""
+
+import os
 
 
 def run(cont, util, shell, argv=None):
-    """Activate haskell container in preparation for deployment."""
+    """Place a symbolic link of pandoc in a writable directory in PATH."""
     del argv
 
     with util.Task("Preparing for deployment to PyPI"):
         hs_ver = "7.8.4"
-        cont.fetch_and_import("setup/project/configure_haskell.py").run(cont,
-                                                                        util,
-                                                                        shell,
-                                                                        hs_ver)
+        hs_script = "setup/project/configure_haskell.py"
+        hs_cont = cont.fetch_and_import(hs_script).get(cont,
+                                                       util,
+                                                       shell,
+                                                       hs_ver)
+
+        with hs_cont.activated():
+            pandoc_binary = util.which("pandoc")
+
+        if os.environ.get("CI", None):
+            # Find the first directory in PATH that is in /home, eg
+            # writable by the current user and make a symbolic link
+            # from the pandoc binary to.
+            for path in os.environ.get("PATH", "").split(":"):
+                if (os.path.commonprefix(os.path.expanduser("~"),
+                                         path) == os.path.expanduser("~")):
+                    os.symlink(pandoc_binary, os.path.join(path, "pandoc"))


### PR DESCRIPTION
Environment variables are not preserved between before_deploy
and deploy, so we need to link pandoc in place.