### PR TITLE
Run style guide checks in bulk, as opposed to individually.

### DIFF
--- a/DICTIONARY
+++ b/DICTIONARY
@@ -8,6 +8,7 @@ Distro
 EOF
 LanguageBase
 LanguageContainer
+PyPI
 PyPy
 REPOSITORIES
 _POLYSQUARE_ACTIVATED_LANGUAGE

--- a/ciscripts/bootstrap.py
+++ b/ciscripts/bootstrap.py
@@ -379,6 +379,10 @@ class ContainerDir(ContainerBase):
             if self._force_created_scripts_dir:
                 self._delete(self._scripts_dir)
 
+        with util.Task("""Cleaning linter cache files"""):
+            self._delete(self.named_cache_dir("tech_terms"))
+            self._delete(self.named_cache_dir("code_spelling_cache"))
+
     def script_path(self, relative_path):
         """Get absolute path to script specified at relative_path.
 

--- a/ciscripts/check/project/lint.py
+++ b/ciscripts/check/project/lint.py
@@ -44,7 +44,11 @@ def run(cont,  # suppress(too-many-arguments)
                      linter,
                      *args)
 
-    with util.Task("""Linting files using polysquare style guide linter"""):
+    def run_linters_on_code_files(extensions,
+                                  exclusions,
+                                  directories,
+                                  block_regexps):
+        """Run polysquare-generic-file-linter on code files."""
         for directory in [os.path.realpath(d) for d in directories]:
             matching = ["*.{0}".format(e) for e in extensions]
             not_matching = ([e for e in exclusions] +
@@ -57,36 +61,51 @@ def run(cont,  # suppress(too-many-arguments)
                 r"\bsuppress\([^\s]*\)"
             ]
 
-            lint("polysquare-generic-file-linter",
-                 *(util.apply_to_files(lambda x: x,
-                                       directory,
-                                       matching,
-                                       not_matching) +
-                   ["--spellcheck-cache",
-                    cache_dir,
-                    "--log-technical-terms-to",
-                    technical_terms_path,
-                    "--block-regexps"] +
-                   block_regexps))
+            files_to_lint = util.apply_to_files(lambda x: x,
+                                                directory,
+                                                matching,
+                                                not_matching)
 
-    with util.Task("""Linting markdown documentation"""):
+            if len(files_to_lint):
+                lint("polysquare-generic-file-linter",
+                     *(files_to_lint +
+                       ["--spellcheck-cache",
+                        cache_dir,
+                        "--log-technical-terms-to",
+                        technical_terms_path,
+                        "--block-regexps"] +
+                       block_regexps))
+
+    def run_linters_on_markdown_files(exclusions,
+                                      directories):
+        """Run spellcheck-linter and markdownlint on markdown files."""
         for directory in [os.path.realpath(d) for d in directories]:
             matching = ["*.md"]
             not_matching = ([e for e in exclusions] +
                             [os.path.join(cont.path(), "*")])
 
-            util.apply_to_files(lambda p: lint("mdl", p),
-                                directory,
-                                matching,
-                                not_matching)
-
             cache_dir = cont.named_cache_dir("markdown_spelling_cache")
-            lint("spellcheck-linter",
-                 *(util.apply_to_files(lambda x: x,
-                                       directory,
-                                       matching,
-                                       not_matching) +
-                   ["--spellcheck-cache",
-                    cache_dir,
-                    "--technical-terms",
-                    technical_terms_path]))
+            files_to_lint = util.apply_to_files(lambda p: p,
+                                                directory,
+                                                matching,
+                                                not_matching)
+
+            if len(files_to_lint) > 0:
+                lint("spellcheck-linter",
+                     *(files_to_lint +
+                       ["--spellcheck-cache",
+                        cache_dir,
+                        "--technical-terms",
+                        technical_terms_path]))
+
+                for markdown_file in files_to_lint:
+                    lint("mdl", markdown_file)
+
+    with util.Task("""Linting files using polysquare style guide linter"""):
+        run_linters_on_code_files(extensions,
+                                  exclusions,
+                                  directories,
+                                  block_regexps)
+
+    with util.Task("""Linting markdown documentation"""):
+        run_linters_on_markdown_files(extensions, directories)

--- a/ciscripts/check/python/check.py
+++ b/ciscripts/check/python/check.py
@@ -50,9 +50,12 @@ def run(cont, util, shell, argv=None):
         excl = [
             os.path.join(os.getcwd(), ".eggs", "*"),
             os.path.join(os.getcwd(), "*.egg", "*"),
-            "*/build/*",
-            "*/dist/*",
-            "*.egg-info/*"
+            os.path.join(os.getcwd(), "*", "build", "*"),
+            os.path.join(os.getcwd(), "build", "*"),
+            os.path.join(os.getcwd(), "*", "dist", "*"),
+            os.path.join(os.getcwd(), "dist", "*"),
+            os.path.join(os.getcwd(), "*", "*.egg-info", "*"),
+            os.path.join(os.getcwd(), "*.egg-info", "*")
         ] + (result.lint_exclude or list())
 
         cont.fetch_and_import("check/project/lint.py").run(cont,

--- a/ciscripts/setup/project/setup.py
+++ b/ciscripts/setup/project/setup.py
@@ -18,10 +18,12 @@ def run(cont, util, shell, argv=None):
     with util.Task("""Setting up generic project"""):
         rb_ver = "2.1.5"
         py_ver = "2.7"
+        hs_ver = "7.8.4"
 
         py_util = cont.fetch_and_import("python_util.py")
         config_python = "setup/project/configure_python.py"
         config_ruby = "setup/project/configure_ruby.py"
+        config_haskell = "setup/project/configure_haskell.py"
 
         rb_cont = cont.fetch_and_import(config_ruby).run(cont,
                                                          util,
@@ -31,6 +33,16 @@ def run(cont, util, shell, argv=None):
                                                            util,
                                                            shell,
                                                            py_ver)
+        hs_cont = cont.fetch_and_import(config_haskell).run(cont,
+                                                            util,
+                                                            shell,
+                                                            hs_ver)
+
+        with util.Task("""Installing pandoc"""):
+            util.where_unavailable("pandoc",
+                                   hs_cont.install_cabal_pkg,
+                                   cont,
+                                   "pandoc")
 
         with util.Task("""Installing markdownlint"""):
             util.where_unavailable("mdl",

--- a/ciscripts/util.py
+++ b/ciscripts/util.py
@@ -440,6 +440,8 @@ def url_error():
 
 def url_opener():
     """Return a function that opens urls as files, performing retries."""
+    from ssl import SSLError
+
     try:
         from urllib.request import urlopen
     except ImportError:
@@ -458,7 +460,7 @@ def url_opener():
         while retrycount != 0:
             try:
                 return urlopen(*args, **kwargs)
-            except url_error():
+            except (url_error(), SSLError):
                 retrycount -= 1
 
         raise url_error()(u"""Failed to open URL {0}, """


### PR DESCRIPTION
This allows polysquare-generic-file-linter to use its internal
parallelization, which massively speeds up check time.