### PR TITLE
Only install haskell if deploying.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
  # As a special case for this project, we specify our ciscripts
  # directory as -r so that changes from the pull-request are
  # used during the build process.
- - eval "$(curl -LSs file://$(pwd)/ciscripts/bootstrap.py | python /dev/stdin -d $(pwd)/container -s container-setup.py -r $(pwd) -e)"
+ - eval "$(curl -LSs --connect-timeout 2 --retry 100 file://$(pwd)/ciscripts/bootstrap.py | python /dev/stdin -d $(pwd)/container -s container-setup.py -r $(pwd) -e)"
 script:
  - polysquare_run check/python/check.py --coverage-exclude "*/__init__.py" --lint-exclude "*/sample/*"
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
  # As a special case for this project, we specify our ciscripts
  # directory as -r so that changes from the pull-request are
  # used during the build process.
+ - rm -rf container
  - eval "$(curl -LSs --connect-timeout 2 --retry 100 file://$(pwd)/ciscripts/bootstrap.py | python /dev/stdin -d $(pwd)/container -s container-setup.py -r $(pwd) -e)"
 script:
  - polysquare_run check/python/check.py --coverage-exclude "*/__init__.py" --lint-exclude "*/sample/*"

--- a/ciscripts/coverage/python/coverage.py
+++ b/ciscripts/coverage/python/coverage.py
@@ -26,4 +26,4 @@ def run(cont, util, shell, argv=None):
                 assert os.path.exists(tests_dir)
 
                 with util.in_dir(tests_dir):
-                    util.execute(cont, util.running_output, "coveralls")
+                    util.execute(cont, util.running_output, "coveralls",)

--- a/ciscripts/setup/project/setup.py
+++ b/ciscripts/setup/project/setup.py
@@ -18,12 +18,10 @@ def run(cont, util, shell, argv=None):
     with util.Task("""Setting up generic project"""):
         rb_ver = "2.1.5"
         py_ver = "2.7"
-        hs_ver = "7.8.4"
 
         py_util = cont.fetch_and_import("python_util.py")
         config_python = "setup/project/configure_python.py"
         config_ruby = "setup/project/configure_ruby.py"
-        config_haskell = "setup/project/configure_haskell.py"
 
         rb_cont = cont.fetch_and_import(config_ruby).run(cont,
                                                          util,
@@ -33,16 +31,6 @@ def run(cont, util, shell, argv=None):
                                                            util,
                                                            shell,
                                                            py_ver)
-        hs_cont = cont.fetch_and_import(config_haskell).run(cont,
-                                                            util,
-                                                            shell,
-                                                            hs_ver)
-
-        with util.Task("""Installing pandoc"""):
-            util.where_unavailable("pandoc",
-                                   hs_cont.install_cabal_pkg,
-                                   cont,
-                                   "pandoc")
 
         with util.Task("""Installing markdownlint"""):
             util.where_unavailable("mdl",

--- a/ciscripts/setup/python/setup.py
+++ b/ciscripts/setup/python/setup.py
@@ -79,6 +79,7 @@ def run(cont, util, shell, argv=None):
             # analysis tools can successfully import them.
             with py_cont.deactivated(util):
                 _install_test_dependencies(cont, util, py_util)
-                py_util.pip_install(cont, util, "coverage", "coveralls")
+                py_util.pip_install(cont, util, "coverage")
 
             _install_test_dependencies(cont, util, py_util)
+            py_util.pip_install(cont, util, "coverage", "coveralls")

--- a/ciscripts/util.py
+++ b/ciscripts/util.py
@@ -428,6 +428,13 @@ def where_unavailable(executable, function, *args, **kwargs):
     return None
 
 
+def prepare_deployment(function, *args, **kwargs):
+    """Call function if this build is a build that will be deployed later."""
+    if (os.environ.get("TRAVIS_PULL_REQUEST", None) == "false" and
+            os.environ.get("TRAVIS_BRANCH", None) == "master"):
+        function(*args, **kwargs)
+
+
 def url_error():
     """Return class representing a failed urlopen."""
     try:
@@ -441,6 +448,7 @@ def url_error():
 def url_opener():
     """Return a function that opens urls as files, performing retries."""
     from ssl import SSLError
+    from socket import timeout
 
     try:
         from urllib.request import urlopen
@@ -460,7 +468,7 @@ def url_opener():
         while retrycount != 0:
             try:
                 return urlopen(*args, **kwargs)
-            except (url_error(), SSLError):
+            except (url_error(), SSLError, timeout):
                 retrycount -= 1
 
         raise url_error()(u"""Failed to open URL {0}, """

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(name="polysquare-ci-scripts",
       license="MIT",
       keywords="development linters",
       packages=find_packages(exclude=["test"]),
-      setup_requires=["setuptools-markdown>=0.1"],
       extras_require={
           "green": [
               "nose",
@@ -38,7 +37,8 @@ setup(name="polysquare-ci-scripts",
               "six",
               "testtools"
           ],
-          "polysquarelint": ["polysquare-setuptools-lint"]
+          "polysquarelint": ["polysquare-setuptools-lint"],
+          "upload": ["setuptools-markdown>=0.1"]
       },
       dependency_links=[
           ("https://github.com/smspillaz/nose-parameterized/tarball/"


### PR DESCRIPTION
This saves lots of time on pull-requests where we don't care
about converting the markdown documentation to ReStructuredText.