### PR TITLE
Set RUBIES_ROOT when using rvm-download

### DIFF
--- a/ciscripts/setup/project/configure_ruby.py
+++ b/ciscripts/setup/project/configure_ruby.py
@@ -150,7 +150,9 @@ def posix_ruby_installer(lang_dir, ruby_build_dir, container, util, shell):
                              util.long_running_suppressed_output(),
                              "bash", rvm_download, version,
                              env={
-                                 "RBENV_ROOT": lang_dir
+                                 "RBENV_ROOT": lang_dir,
+                                 "RUBIES_ROOT": os.path.join(lang_dir,
+                                                             "versions")
                              },
                              instant_fail=True)
 


### PR DESCRIPTION
The rbenv-download script now checks to see if the
folder specified by RUBIES_ROOT exists and makes it if
it doesn't. This requires the variable to be set