### PR TITLE
Prefer user value for instant_fail, but use True by Default

### DIFF
--- a/ciscripts/python_util.py
+++ b/ciscripts/python_util.py
@@ -85,7 +85,7 @@ def pip_install(container, util, *args, **kwargs):
                             pip_install_args[4:])
 
     util.execute(*pip_install_args,
-                 instant_fail=True,
+                 instant_fail=kwargs.pop("instant_fail", True),
                  **kwargs)
 
 


### PR DESCRIPTION
Previously we always set instant_fail to true, ignoring the
user setting