### PR TITLE
Ensure process stderr ends up on new indented line

### DIFF
--- a/ciscripts/util.py
+++ b/ciscripts/util.py
@@ -285,9 +285,13 @@ def running_output(process, outputs):
     finally:
         stdout.join()
 
-    for line in stderr_lines:
-        IndentedLogger.message(line.decode("utf-8"))
-        state.printed_message = True
+    # Print a new line before printing any stderr messages
+    if len(stderr_lines):
+        IndentedLogger.message("\n")
+
+        for line in stderr_lines:
+            IndentedLogger.message(line.decode("utf-8"))
+            state.printed_message = True
 
     if state.printed_message:
         print_message("\n")

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -459,7 +459,7 @@ class TestExecute(TestCase):
                          "import sys; "
                          "sys.stdout.write('a\\nb'); "
                          "sys.stderr.write('c'); "
-                         "sys.stdout.write('d\\n')")
+                         "sys.stdout.write('d')")
 
         self.assertEqual(captured_output.stderr.replace("\r\n", "\n"),
                          "\na\nbd\nc\n")


### PR DESCRIPTION
Previously we were assuming that the standard out would finish on
a new line - this was not always true.