### PR TITLE
Read contents of setup.py ourselves to avoid using pip

### DIFF
--- a/ciscripts/python_util.py
+++ b/ciscripts/python_util.py
@@ -12,9 +12,33 @@
 
 import os
 
+import re
+
 import subprocess
 
+import warnings
+
+from collections import defaultdict
+
+from contextlib import contextmanager
+
+from distutils.version import LooseVersion
+
 from itertools import chain
+
+
+def fetch_packages_in_active_python():
+    """Fetch a dict of installed packages for the current python.
+
+    The dict shall have the format { "package": "version" }.
+    """
+    out = subprocess.check_output(["pip", "list"]).decode().splitlines()
+    reg = r"\(|\)|,|\s+"
+    tuples = [[w for w in re.split(reg, l) if w][:2] for l in out]
+    return dict([tuple(t) for t in tuples])
+
+_PACKAGES_FOR_PYTHON = defaultdict(fetch_packages_in_active_python)
+_PARSED_SETUP_FILES = dict()
 
 
 def get_python_version(precision):  # suppress(unused-function)
@@ -61,12 +85,52 @@ def python_is_pypy():  # suppress(unused-function)
                                       stderr=subprocess.PIPE).communicate()[1]
 
 
-def pip_install(container, util, *args, **kwargs):
-    """Install packages listed in args with pip.
+def _packages_to_install(installed, requested):
+    """Return a list of packages to install.
 
-    This function does caching to make sure that we don't double-download
-    packages.
+    Already installed packages are skipped. Things like command line
+    options will implicitly pass right through.
     """
+    def real_identifier(requested_package):
+        """Return egg component of package string."""
+        if "#egg=" in requested_package:
+            return requested_package.split("#egg=")[1]
+
+        return requested_package
+
+    # suppress(too-many-return-statements)
+    def out_of_date(requested, installed):
+        """Return true if requested is out of date."""
+        if not installed:
+            return True
+
+        installed = LooseVersion(installed)
+
+        if "==" in requested:
+            return LooseVersion(requested.split("==")[1]) != installed
+        elif ">=" in requested:
+            return installed < LooseVersion(requested.split(">=")[1])
+        elif ">" in requested:
+            return installed <= LooseVersion(requested.split(">")[1])
+        elif "<=" in requested:
+            return installed > LooseVersion(requested.split(">=")[1])
+        elif "<" in requested:
+            return installed >= LooseVersion(requested.split(">")[1])
+
+        return False
+
+    # Do some simple version checks
+    version_symbols_regex = r">|>=|==|<=|<"
+    pkgs = [r for r in requested
+            if out_of_date(real_identifier(r),
+                           installed.get(re.split(version_symbols_regex,
+                                                  real_identifier(r))[0]))]
+
+    return list(set(pkgs))
+
+
+def _pip_install_internal(container, util, pip_path, *args, **kwargs):
+    """Run pip install, without removing redundant packages."""
     pip_install_args = [
         container,
         util.long_running_suppressed_output(),
@@ -87,23 +151,93 @@ def pip_install(container, util, *args, **kwargs):
     util.execute(*pip_install_args,
                  instant_fail=kwargs.pop("instant_fail", True),
                  **kwargs)
+    _PACKAGES_FOR_PYTHON[pip_path] = fetch_packages_in_active_python()
 
 
-def pip_install_deps(py_cont, util, target, *args, **kwargs):
+def pip_install(container, util, *args, **kwargs):
+    """Install packages listed in args with pip.
+
+    This function does caching to make sure that we don't double-download
+    packages.
+    """
+    active_python = util.which("python")
+    to_install = _packages_to_install(_PACKAGES_FOR_PYTHON[active_python],
+                                      list(args))
+
+    if len([p for p in to_install if not p.startswith("-")]):
+        _pip_install_internal(container,
+                              util,
+                              active_python,
+                              *to_install,
+                              **kwargs)
+
+
+def _parse_setup_py():
+    """Parse /setup.py and return its keyword arguments."""
+    current_setup_py = os.path.join(os.getcwd(), "setup.py")
+    try:
+        return _PARSED_SETUP_FILES[current_setup_py]
+    except KeyError:  # suppress(pointless-except)
+        pass
+
+    setuptools_arguments = dict()
+
+    @contextmanager
+    def patched_setuptools():
+        """Import setuptools and patch it."""
+        import setuptools
+
+        def setup_hook(*args, **kwargs):
+            """Hook the setup function and log its arguments."""
+            del args
+
+            setuptools_arguments.update(kwargs)
+
+        old_setup = setuptools.setup
+        setuptools.setup = setup_hook
+
+        try:
+            yield
+        finally:
+            setuptools.setup = old_setup
+
+    with patched_setuptools():
+        import imp
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            imp.load_source("setup.py", current_setup_py)
+
+    # Remember result, as querying it takes a second.
+    _PARSED_SETUP_FILES[current_setup_py] = setuptools_arguments
+    return setuptools_arguments
+
+
+def _dependencies_to_update(installed, target):
+    """Return a list of dependencies to install."""
+    requested = _parse_setup_py().get("extras_require", dict()).get(target,
+                                                                    dict())
+
+    return _packages_to_install(installed, requested)
+
+
+def pip_install_deps(cont, util, target, *args, **kwargs):
     """Install dependencies using pip.
 
-    Dependencies are not installed if they have already been installed for this
-    project.
+    Dependencies are not installed if we've already got them installed. We
+    use a shortcut method to determine that.
     """
-    stampfile = os.path.join(py_cont.named_cache_dir("pip-setuptools"),
-                             ".installed-{0}".format(target))
+    active_python = util.which("python")
+    initially_installed_packages = _PACKAGES_FOR_PYTHON[active_python]
+    pip_install_args = [
+        cont,
+        util,
+        active_python
+    ]
 
-    if not os.path.exists(stampfile):
-        pip_install_args = [
-            py_cont,
-            util,
-            "-e",
-            ".[{0}]".format(target)
-        ] + list(args)
+    to_install = (_dependencies_to_update(initially_installed_packages,
+                                          target) +
+                  _packages_to_install(initially_installed_packages,
+                                       list(args)))
 
-        pip_install(*pip_install_args, **kwargs)
+    if len([p for p in to_install if not p.startswith("-")]):
+        _pip_install_internal(*(pip_install_args + to_install), **kwargs)

--- a/ciscripts/python_util.py
+++ b/ciscripts/python_util.py
@@ -135,9 +135,7 @@ def _pip_install_internal(container, util, pip_path, *args, **kwargs):
         container,
         util.long_running_suppressed_output(),
         "pip",
-        "install",
-        "--download-cache",
-        container.named_cache_dir("pip-cache")
+        "install"
     ] + list(args)
 
     allow_external = kwargs.pop("polysquare_allow_external", None) or list()

--- a/ciscripts/setup/project/configure_os.py
+++ b/ciscripts/setup/project/configure_os.py
@@ -252,7 +252,7 @@ def run(container,
                   "polysquare-travis-container/tarball/master")
         util.where_unavailable("psq-travis-container-create",
                                py_util.pip_install,
-                               py_cont,
+                               container,
                                util,
                                remote,
                                "--process-dependency-links",

--- a/ciscripts/setup/project/setup.py
+++ b/ciscripts/setup/project/setup.py
@@ -61,7 +61,7 @@ def run(cont, util, shell, argv=None):
             linter = "polysquare-generic-file-linter"
             util.where_unavailable(linter,
                                    py_util.pip_install,
-                                   py_cont,
+                                   cont,
                                    util,
                                    linter,
                                    instant_fail=True,

--- a/ciscripts/setup/python/setup.py
+++ b/ciscripts/setup/python/setup.py
@@ -9,16 +9,19 @@ import platform
 
 from collections import defaultdict
 
+from distutils.version import LooseVersion
 
-def _install_test_dependencies(cont, util, py_util):
+
+def _install_test_dependencies(cont, util, py_util, *args):
     """Install testing dependencies for python project."""
     py_util.pip_install(cont,
                         util,
                         ("git+git://github.com/smspillaz/green.git"
-                         "@process-overhaul-modules-subprocesses"))
+                         "@process-overhaul-modules-subprocesses#egg=green"))
     py_util.pip_install_deps(cont,
                              util,
-                             "green")
+                             "green",
+                             *args)
 
 
 def _prepare_python_deployment(cont, py_cont, util, shell, py_util):
@@ -43,12 +46,15 @@ def _prepare_python_deployment(cont, py_cont, util, shell, py_util):
 
 def _upgrade_pip(cont, util):
     """Upgrade pip installation in current virtual environment."""
-    util.execute(cont,
-                 util.long_running_suppressed_output(),
-                 "pip",
-                 "install",
-                 "--upgrade",
-                 "pip")
+    import pip
+
+    if LooseVersion(pip.__version__) < LooseVersion("7.1.0"):
+        util.execute(cont,
+                     util.long_running_suppressed_output(),
+                     "pip",
+                     "install",
+                     "--upgrade",
+                     "pip")
 
 
 def run(cont, util, shell, argv=None):
@@ -76,7 +82,7 @@ def run(cont, util, shell, argv=None):
         # errors when attempting to remove the old version of
         # pip, so don't perform, the upgrade on Windows
         if platform.system() != "Windows":
-            with util.Task("""Upgrading pip"""):
+            with util.Task("""Ensuring that pip is up to date"""):
                 with py_cont.deactivated(util):
                     _upgrade_pip(cont, util)
 
@@ -95,11 +101,16 @@ def run(cont, util, shell, argv=None):
             # They need to be installed in the container so that static
             # analysis tools can successfully import them.
             with py_cont.deactivated(util):
-                _install_test_dependencies(cont, util, py_util)
-                py_util.pip_install(cont, util, "coverage")
+                _install_test_dependencies(cont,
+                                           util,
+                                           py_util,
+                                           "coverage")
 
-            _install_test_dependencies(cont, util, py_util)
-            py_util.pip_install(cont, util, "coverage", "coveralls")
+            _install_test_dependencies(cont,
+                                       util,
+                                       py_util,
+                                       "coverage",
+                                       "coveralls")
 
         util.prepare_deployment(_prepare_python_deployment,
                                 cont,

--- a/ciscripts/setup/python/setup.py
+++ b/ciscripts/setup/python/setup.py
@@ -91,10 +91,7 @@ def run(cont, util, shell, argv=None):
         with util.Task("""Installing python linters"""):
             py_util.pip_install_deps(cont,
                                      util,
-                                     "polysquarelint",
-                                     "--process-dependency-links",
-                                     "--allow-external",
-                                     "green")
+                                     "polysquarelint")
 
         with util.Task("""Installing python test runners"""):
             # Install testing dependencies both inside and outside container.

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(name="polysquare-ci-scripts",
               "nose",
               "nose-parameterized>=0.4.0",
               "mock",
-              "green>=1.12.0",
+              "green",
               "setuptools-green",
               "six",
               "testtools"
@@ -41,9 +41,5 @@ setup(name="polysquare-ci-scripts",
           "polysquarelint": ["polysquare-setuptools-lint"],
           "upload": ["setuptools-markdown>=0.1"]
       },
-      dependency_links=[
-          ("http://github.com/smspillaz/green/tarball/"
-           "process-overhaul-modules-subprocesses#egg=green-1.12.0")
-      ],
       zip_safe=True,
       include_package_data=True)

--- a/test/test_cmake.py
+++ b/test/test_cmake.py
@@ -15,6 +15,7 @@ from test.testutil import (CIScriptExitsWith,
                            CapturedOutput,
                            WHICH_SCRIPT,
                            acceptance_test_for,
+                           copy_scripts_to_directory,
                            format_with_args)
 
 import ciscripts.util as util
@@ -27,6 +28,8 @@ REQ_PROGRAMS = [
     "psq-travis-container-exec",
     "psq-travis-container-create"
 ]
+
+__file__ = os.path.abspath(__file__)
 
 
 class TestCMakeContainerSetup(acceptance_test_for("cmake", REQ_PROGRAMS)):
@@ -51,6 +54,7 @@ class TestCMakeContainerSetup(acceptance_test_for("cmake", REQ_PROGRAMS)):
         container = self.__class__.container
         output_strategy = util.output_on_fail
         script = WHICH_SCRIPT.format(program)
+        copy_scripts_to_directory(os.getcwd())
         self.assertEqual(self.__class__.lang_container.execute(container,
                                                                output_strategy,
                                                                "python",

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -557,16 +557,14 @@ def acceptance_test_for(project_type, expected_programs):
 
         _PROGRAMS.extend(expected_programs)
 
-        @parameterized.expand(_PROGRAMS,
-                              testcase_func_doc=format_with_args(0))
+        @parameterized.expand(_PROGRAMS, testcase_func_doc=format_with_args(0))
         def test_program_is_available_in_python_script(self, program):
             """Executable {0} is available after running setup."""
             temp_dir = self.__class__.container_temp_dir
             self.assertThat(util.which(program),
                             IsInSubdirectoryOf(temp_dir))
 
-        @parameterized.expand(_PROGRAMS,
-                              testcase_func_doc=format_with_args(0))
+        @parameterized.expand(_PROGRAMS, testcase_func_doc=format_with_args(0))
         def test_program_is_available_in_parent_shell(self, program):
             """Executable {0} is available in parent shell after setup."""
             script = WHICH_SCRIPT.format(program)

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -36,6 +36,8 @@ from testtools import TestCase
 from testtools.content import text_content
 from testtools.matchers import Mismatch
 
+__file__ = os.path.abspath(__file__)
+
 
 class CapturedOutput(object):  # suppress(too-few-public-methods)
 
@@ -384,6 +386,19 @@ def _copytree_ignore_notfound(src, dst):
             pass
 
 
+def copy_scripts_to_directory(target):
+    """Utility method to copy CI script to current directory.
+
+    They will be located at /ciscripts/.
+    """
+    parent = os.path.realpath(os.path.join(os.path.dirname(__file__),
+                                           ".."))
+    assert "ciscripts" in os.listdir(parent)
+
+    shutil.copytree(os.path.join(parent, "ciscripts"),
+                    os.path.join(target, "ciscripts"))
+
+
 def _safe_rmtree(directory):
     """Call shutil.rmtree, but ignore ENOENT."""
     try:
@@ -443,10 +458,6 @@ def acceptance_test_for(project_type, expected_programs):
         @classmethod
         def setUpClass(cls):  # suppress(N802)
             """Call container setup script."""
-            parent = os.path.realpath(os.path.join(os.path.dirname(__file__),
-                                                   ".."))
-            assert "ciscripts" in os.listdir(parent)
-
             temp_dir_prefix = "{}_acceptance_test".format(project_type)
             cls.container_temp_dir = tempfile.mkdtemp(dir=os.getcwd(),
                                                       prefix=temp_dir_prefix)
@@ -466,10 +477,8 @@ def acceptance_test_for(project_type, expected_programs):
                 except (shutil.Error, OSError):  # suppress(pointless-except)
                     pass
 
-            shutil.copytree(os.path.join(parent, "ciscripts"),
-                            os.path.join(cls.container_temp_dir,
-                                         "_scripts",
-                                         "ciscripts"))
+            copy_scripts_to_directory(os.path.join(cls.container_temp_dir,
+                                                   "_scripts"))
 
             setup_script = "setup/{type}/setup.py".format(type=project_type)
             cls.setup_container_output = CapturedOutput()
@@ -563,6 +572,7 @@ def acceptance_test_for(project_type, expected_programs):
             script = WHICH_SCRIPT.format(program)
             py_cmd = "python -c \"{}\"".format(script)
             with self.in_parent_context(py_cmd) as cmd:
+                copy_scripts_to_directory(os.getcwd())
                 self.assertThat(cmd, SubprocessExitsWith(0))
 
     return AcceptanceTestForProject


### PR DESCRIPTION
Invoking pip to read setup.py for dependenecies is slow -
read it ourselves and cache the result.