### PR TITLE
Parse setup.py in a subprocess

### DIFF
--- a/DICTIONARY
+++ b/DICTIONARY
@@ -10,6 +10,7 @@ DEPENDENCIES
 DNS
 Distro
 EOF
+FIELD
 LanguageBase
 LanguageContainer
 PATHEXT

--- a/ciscripts/bootstrap.py
+++ b/ciscripts/bootstrap.py
@@ -558,6 +558,14 @@ class ContainerDir(ContainerBase):
         except KeyError:
             return None
 
+    def fetch_script(self,
+                     script_path,
+                     domain="public-travis-scripts.polysquare.org"):
+        """Wrapper for _fetch_script, returns a FetchedModule."""
+        info = self.script_path(script_path)
+        _fetch_script(info, script_path, domain)
+        return info
+
     def fetch_and_import(self,
                          script_path,
                          domain="public-travis-scripts.polysquare.org"):
@@ -573,9 +581,7 @@ class ContainerDir(ContainerBase):
 
         # First try to find the script locally in the
         # current working directory.
-        info = self.script_path(script_path)
-        _fetch_script(info, script_path)
-
+        info = self.fetch_script(script_path, domain)
         key = "{0}/{1}".format(domain, script_path)
 
         try:

--- a/ciscripts/parse_setup.py
+++ b/ciscripts/parse_setup.py
@@ -1,0 +1,52 @@
+# /ciscripts/parse_setup.py
+#
+# Python utility script to read a /setup.py file and dump requested fields.
+#
+# It should be used like so:
+#   python /parse_setup.py FIELD [FIELD...]
+#
+# See /LICENCE.md for Copyright information
+"""Python related utility functions."""
+
+import json
+
+import sys
+
+import warnings
+
+from contextlib import contextmanager
+
+
+def main(argv):
+    """Parse /setup.py and return requested fields."""
+    setuptools_arguments = dict()
+
+    @contextmanager
+    def patched_setuptools():
+        """Import setuptools and patch it."""
+        import setuptools
+
+        def setup_hook(*args, **kwargs):
+            """Hook the setup function and log its arguments."""
+            del args
+
+            setuptools_arguments.update(kwargs)
+
+        old_setup = setuptools.setup
+        setuptools.setup = setup_hook
+
+        try:
+            yield
+        finally:
+            setuptools.setup = old_setup
+
+    with patched_setuptools():
+        import imp
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            imp.load_source("setup.py", "setup.py")
+
+    return {k: setuptools_arguments[k] for k in argv
+            if k in setuptools_arguments}
+
+sys.stdout.write(json.dumps(main(sys.argv[1:])))


### PR DESCRIPTION
Parsing might have dependencies on the particular python
version in use, so we need to make sure that when we're
installing dependencies for a particular python container
that we parse the setup.py file using that python.