### PR TITLE
Enforce installation of recent polysquare setuptools extensions

### DIFF
--- a/ciscripts/setup/project/configure_os.py
+++ b/ciscripts/setup/project/configure_os.py
@@ -242,21 +242,16 @@ def run(container,
 
     py_ver = defaultdict(lambda: "3.4.1")
     py_util = container.fetch_and_import("python_util.py")
-    py_cont = container.fetch_and_import(config_python).run(container,
-                                                            util,
-                                                            shell,
-                                                            py_ver)
+    container.fetch_and_import(config_python).run(container,
+                                                  util,
+                                                  shell,
+                                                  py_ver)
 
     with util.Task("""Installing polysquare-travis-container"""):
-        remote = ("https://github.com/polysquare/"
-                  "polysquare-travis-container/tarball/master")
-        util.where_unavailable("psq-travis-container-create",
-                               py_util.pip_install,
-                               container,
-                               util,
-                               remote,
-                               path=py_cont.executable_path(),
-                               instant_fail=True)
+        py_util.pip_install(container,
+                            util,
+                            "polysquare-travis-container>=0.0.8",
+                            instant_fail=True)
 
     def install(distro, distro_version, distro_arch):
         """Install distribution specified in configuration."""

--- a/ciscripts/setup/python/setup.py
+++ b/ciscripts/setup/python/setup.py
@@ -18,6 +18,9 @@ def _install_test_dependencies(cont, util, py_util, *args):
                              util,
                              "green",
                              *args)
+    py_util.pip_install(cont,
+                        util,
+                        "setuptools-green>=0.0.13")
 
 
 def _prepare_python_deployment(cont, py_cont, util, shell, py_util):
@@ -88,6 +91,9 @@ def run(cont, util, shell, argv=None):
             py_util.pip_install_deps(cont,
                                      util,
                                      "polysquarelint")
+            py_util.pip_install(cont,
+                                util,
+                                "polysquare-setuptools-lint>=0.0.22")
 
         with util.Task("""Installing python test runners"""):
             # Install testing dependencies both inside and outside container.

--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,11 @@ setup(name="polysquare-ci-scripts",
               "nose-parameterized>=0.5.0",
               "mock",
               "green>=2.0.0",
-              "setuptools-green>=0.0.11",
+              "setuptools-green>=0.0.13",
               "six",
               "testtools"
           ],
-          "polysquarelint": ["polysquare-setuptools-lint>=0.0.17"],
+          "polysquarelint": ["polysquare-setuptools-lint>=0.0.21"],
           "upload": ["setuptools-markdown>=0.1"]
       },
       zip_safe=True,


### PR DESCRIPTION
This ensures that we're always calling into the correct
API