### PR TITLE
bii: Don't mark cmake-build as ephemeral

### DIFF
--- a/ciscripts/deploy/bii/deploy.py
+++ b/ciscripts/deploy/bii/deploy.py
@@ -40,5 +40,5 @@ def run(cont, util, shell, argv=None):
 
     with util.Task("""Preparing for deployment to biicode"""):
         if os.environ.get("CI", None):
-            build = cont.named_cache_dir("cmake-build")
+            build = cont.named_cache_dir("cmake-build", ephemeral=False)
             _move_directories_ignore_errors(_BII_LAYOUT, build, os.getcwd())

--- a/ciscripts/setup/project/configure_bii.py
+++ b/ciscripts/setup/project/configure_bii.py
@@ -45,7 +45,7 @@ def get(container, util, shell, ver_info):
         def clean(self, util_mod):
             """Clean out cruft in the container."""
             super(BiiContainer, self).clean(util_mod)
-            build = container.named_cache_dir("cmake-build", ephemeral=True)
+            build = container.named_cache_dir("cmake-build", ephemeral=False)
             util_mod.force_remove_tree(os.path.join(build, "bin"))
             util_mod.force_remove_tree(os.path.join(build, "lib"))
 


### PR DESCRIPTION
We need to keep its contents for the coverage step later