### PR TITLE
bii: Add coverage hooks

### DIFF
--- a/ciscripts/coverage/bii/__init__.py
+++ b/ciscripts/coverage/bii/__init__.py
@@ -1,0 +1,6 @@
+# /ciscripts/coverage/bii/__init__.py
+#
+# Module loader file for /ciscripts/coverage/bii.
+#
+# See /LICENCE.md for Copyright information
+"""Module loader file for /ciscripts/coverage/bii."""

--- a/ciscripts/coverage/bii/coverage.py
+++ b/ciscripts/coverage/bii/coverage.py
@@ -1,0 +1,35 @@
+# /ciscripts/coverage/bii/coverage.py
+#
+# Submit coverage totals for a bii project to coveralls
+#
+# See /LICENCE.md for Copyright information
+"""Submit coverage totals for a bii project to coveralls."""
+
+import errno
+
+import os
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def _bii_deps_in_place(cont):
+    """Move bii project dependencies into layout.
+
+    The coverage step may require these dependencies to be present.
+    """
+    bii_dir = os.path.join(cont.named_cache_dir("cmake-build"), "bii")
+    try:
+        os.rename(bii_dir, os.path.join(os.getcwd(), "bii"))
+    except OSError as error:
+        if error.errno != errno.ENOENT:
+            raise error
+
+
+def run(cont, util, shell, argv=None):
+    """Submit coverage total to coveralls, with bii specific preparation."""
+    with _bii_deps_in_place(cont):
+        util.fetch_and_import("coverage/cmake/coverage.py").run(cont,
+                                                                util,
+                                                                shell,
+                                                                argv)

--- a/ciscripts/setup/python/setup.py
+++ b/ciscripts/setup/python/setup.py
@@ -5,8 +5,6 @@
 # See /LICENCE.md for Copyright information
 """The main setup script to bootstrap and set up a python project."""
 
-from distutils.version import LooseVersion  # suppress(import-error)
-
 
 def _install_test_dependencies(cont, util, py_util, *args):
     """Install testing dependencies for python project."""
@@ -40,21 +38,6 @@ def _prepare_python_deployment(cont, util, shell, py_util):
         py_util.pip_install(cont, util, "twine")
 
 
-def _upgrade_pip(cont, util):
-    """Upgrade pip installation in current virtual environment."""
-    import pip
-
-    if LooseVersion(pip.__version__) < LooseVersion("7.1.1"):
-        util.execute(cont,
-                     util.long_running_suppressed_output(),
-                     "python",
-                     "-m",
-                     "pip",
-                     "install",
-                     "--upgrade",
-                     "pip")
-
-
 def run(cont, util, shell, argv=None):
     """Install everything necessary to test and check a python project.
 
@@ -79,12 +62,6 @@ def run(cont, util, shell, argv=None):
                                                               util,
                                                               shell,
                                                               py_ver)
-
-        with util.Task("""Ensuring that pip is up to date"""):
-            with py_cont.activated(util):
-                _upgrade_pip(cont, util)
-
-            _upgrade_pip(cont, util)
 
         with util.Task("""Installing python linters"""):
             with py_cont.activated(util):

--- a/test/test_bootstrap.py
+++ b/test/test_bootstrap.py
@@ -80,6 +80,9 @@ def write_bootstrap_script_into_container(directory_name):
     shutil.copyfile(os.path.join(os.path.dirname(bootstrap.__file__),
                                  "bootstrap.py"),
                     os.path.join(scripts_dir, "bootstrap.py"))
+    shutil.copyfile(os.path.join(os.path.dirname(util.__file__),
+                                 "util.py"),
+                    os.path.join(scripts_dir, "util.py"))
 
 
 @contextmanager
@@ -109,9 +112,10 @@ class TrackedLoadedModulesTestCase(TestCase):
         self._loaded_modules = []
 
     def setUp(self):  # suppress(N802)
-        """Ensure that bootstrap.__file__ is absolute."""
+        """Ensure that bootstrap and util __file__ is absolute."""
         super(TrackedLoadedModulesTestCase, self).setUp()
         self.patch(bootstrap, "__file__", os.path.abspath(bootstrap.__file__))
+        self.patch(util, "__file__", os.path.abspath(util.__file__))
 
     def tearDown(self):  # suppress(N802)
         """Ensure that any loaded modules are removed."""
@@ -563,12 +567,6 @@ class TestLanguageContainer(TrackedLoadedModulesTestCase):
 def _write_setup_script(script_contents):
     """Write script_contents to setup script and return its path."""
     loadable = os.path.abspath("container/_scripts")
-    util_script_path = os.path.abspath(os.path.join(loadable,
-                                                    "ciscripts",
-                                                    "util.py"))
-    with make_loadable_module_path(util_script_path, loadable) as f:
-        pass
-
     setup_script_path = os.path.abspath(os.path.join(loadable,
                                                      "ciscripts",
                                                      "setup",


### PR DESCRIPTION
For bii projects, we need to move the deps folder back into
place, as we may be relying on it to find some CMakeUnit files