### PR TITLE
setup: Use vendored requirements with requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+nose==1.3.6
+nose-parameterized==0.5.0
+mock==1.0.1
+green==2.0.1
+setuptools-green<=0.1.0
+six==1.10.0
+testtools==1.7.1
+polysquare-setuptools-lint<=0.1.0

--- a/setup.py
+++ b/setup.py
@@ -32,16 +32,6 @@ setup(name="polysquare-ci-scripts",
           "setuptools"
       ],
       extras_require={
-          "green": [
-              "nose",
-              "nose-parameterized>=0.5.0",
-              "mock",
-              "green>=2.0.0",
-              "setuptools-green>=0.0.13",
-              "six",
-              "testtools"
-          ],
-          "polysquarelint": ["polysquare-setuptools-lint>=0.0.21"],
           "upload": ["setuptools-markdown>=0.1"]
       },
       zip_safe=True,


### PR DESCRIPTION
Don't add extras_requires for various stages anymore, its too
complex and fragile to manage. requirements.txt is fine to express
all dev-dependencies.