### PR TITLE
conan: Put deploy keys into file before deploying

### DIFF
--- a/ciscripts/deploy/conan/before_deploy.py
+++ b/ciscripts/deploy/conan/before_deploy.py
@@ -1,0 +1,29 @@
+# /ciscripts/deploy/conan/before_deploy.py
+#
+# Put conan keys in project directory before deploying.
+#
+# See /LICENCE.md for Copyright information
+"""Put conan keys in project directory before deploying."""
+
+import json
+
+import os
+
+
+def run(cont, util, shell, argv=None):
+    """Put conan keys in project directory before deploying."""
+    assert len(argv)
+    argv = ["deploy/conan/deploy.py"] + (argv or [])
+    cont.fetch_and_import("deploy/script/before_deploy.py").run(cont,
+                                                                util,
+                                                                shell,
+                                                                argv)
+
+    assert os.environ.get("CONAN_USER", None)
+    assert os.environ.get("CONAN_PASS", None)
+
+    with open("conan_keys", "w") as conan_keys_file:
+        conan_keys_file.write(json.dumps({
+            "username": os.environ["CONAN_USER"],
+            "password": os.environ["CONAN_PASS"]
+        }))

--- a/ciscripts/deploy/conan/deploy.py
+++ b/ciscripts/deploy/conan/deploy.py
@@ -7,6 +7,10 @@
 
 import argparse
 
+import json
+
+import os
+
 
 def run(cont, util, shell, argv=None):
     """Place a symbolic link of pandoc in a writable directory in PATH."""
@@ -15,21 +19,21 @@ def run(cont, util, shell, argv=None):
                         help="""Package name""",
                         type=str,
                         required=True)
-    parser.add_argument("--username",
-                        help="""Conan username""",
-                        type=str,
-                        required=True)
-    parser.add_argument("--password",
-                        help="""Conan password""",
-                        type=str,
-                        required=True)
     result = parser.parse_args(argv)
+
+    assert os.path.exists("conan_keys")
+
+    with open("conan_keys", "r") as conan_keys_file:
+        conan_keys = json.loads(conan_keys_file.read())
+
+    username = conan_keys["username"]
+    password = conan_keys["password"]
 
     cont.fetch_and_import("deploy/project/deploy.py").run(cont,
                                                           util,
                                                           shell)
 
-    block = "{user}/{pkg}".format(user=result.username,
+    block = "{user}/{pkg}".format(user=username,
                                   pkg=result.package_name)
     upload_desc = "{pkg}/master@{block}".format(pkg=result.package_name,
                                                 block=block)
@@ -40,14 +44,14 @@ def run(cont, util, shell, argv=None):
                                                                    argv)
 
     with conan_cont.activated(util):
-        with util.Task("""Logging in as {}""".format(result.username)):
+        with util.Task("""Logging in as {}""".format(username)):
             conan_cont.execute(cont,
                                util.running_output,
                                "conan",
                                "user",
-                               result.username,
+                               username,
                                "-p",
-                               result.password)
+                               password)
 
         with util.Task("""Deploying {} to conan""".format(upload_desc)):
             conan_cont.execute(cont,


### PR DESCRIPTION
Passing around the keys in environment variables tends to mangle
them, better to write them out to a file where we have control