### PR TITLE
container: Reference-count when we enter language containers

### DIFF
--- a/test/test_bootstrap.py
+++ b/test/test_bootstrap.py
@@ -429,6 +429,7 @@ class TestLanguageContainer(TrackedLoadedModulesTestCase):
 
     def test_double_activating_container_returns_false(self):
         """Activating container twice returns false on second try."""
+        self.addCleanup(lambda: language_container.deactivate(self._util))
         with testutil.CapturedOutput():
             language_container = self._get_lang_container("language")
             with language_container.activated(self._util):


### PR DESCRIPTION
This fixes subtle problems when contaienrs are entered twice
and then deactiated. If container A is entered and then entered
A again, then exited, we are still in A. Previously, the entire
container would have been deactivated when the user would have
expected that it was activated. Reference count to get around
this problem.