### PR TITLE
Use the --local version of OS containers

### DIFF
--- a/ciscripts/check/python/check.py
+++ b/ciscripts/check/python/check.py
@@ -76,6 +76,7 @@ def lint_python(cont, util, shell, lint_exclude=None):
                                                        util,
                                                        shell,
                                                        py_ver)
+    lint_exclude = (lint_exclude or []) + ["*/container/*"]
 
     with util.Task("""Linting python project"""):
         with py_cont.activated(util):
@@ -90,7 +91,7 @@ def lint_python(cont, util, shell, lint_exclude=None):
                          "python",
                          "setup.py",
                          "polysquarelint",
-                         "--exclusions=" + ",".join(lint_exclude or []),
+                         "--exclusions=" + ",".join(lint_exclude),
                          "--suppress-codes=" + ",".join(suppress),
                          ("--stamp-directory=" +
                           cont.named_cache_dir("polysquarelint-stamp",

--- a/ciscripts/deploy/conan/deploy.py
+++ b/ciscripts/deploy/conan/deploy.py
@@ -137,6 +137,8 @@ def run(cont, util, shell, argv=None):
                            "-c",
                            "import conanfile; "
                            "print(conanfile.VERSION)")
+        version_stream.seek(0)
+        version = str(version_stream.read()).strip()
 
     with conan_cont.activated(util):
         with util.Task("""Logging in as {}""".format(username)):
@@ -155,10 +157,6 @@ def run(cont, util, shell, argv=None):
                    "master",
                    block)
 
-
-
-        version_stream.seek(0)
-        version = str(version_stream.read()).strip()
         run_deploy(cont,
                    util,
                    conan_cont,

--- a/ciscripts/setup/conan/setup.py
+++ b/ciscripts/setup/conan/setup.py
@@ -36,8 +36,6 @@ def run(cont, util, shell, argv=None):
 
     extra_packages = defaultdict(lambda: defaultdict(lambda: []),
                                  Linux=defaultdict(lambda: [
-                                     "python",
-                                     "python-pip",
                                      "ninja-build"
                                  ]),
                                  Windows=defaultdict(lambda: [

--- a/ciscripts/setup/project/configure_os.py
+++ b/ciscripts/setup/project/configure_os.py
@@ -26,7 +26,7 @@ DEFAULT_DISTRO_FOR_SYSTEM = {
 }
 
 DEFAULT_DISTRO_RELEASE_FOR_SYSTEM = {
-    "Linux": "trusty",
+    "Linux": "precise",
     "Darwin": "10.10",
     "Windows": "8.1"
 }

--- a/ciscripts/setup/project/configure_os.py
+++ b/ciscripts/setup/project/configure_os.py
@@ -96,7 +96,8 @@ def get(container,
             """
             args = [
                 "--distro=" + self._distro,
-                "--release=" + self._distro_version
+                "--release=" + self._distro_version,
+                "--local"
             ]
 
             if self._distro_arch:
@@ -242,6 +243,7 @@ def _update_os_container(container,
                              os_container_path,
                              "--distro=" + distro,
                              "--release=" + distro_version,
+                             "--local",
                              *additional_options,
                              instant_fail=True)
 

--- a/ciscripts/setup/project/configure_os.py
+++ b/ciscripts/setup/project/configure_os.py
@@ -268,7 +268,7 @@ def _install_psq_travis_container(cont,
             py_util.pip_install(cont,
                                 util,
                                 "requests",
-                                "polysquare-travis-container>=0.0.23",
+                                "polysquare-travis-container>=0.0.24",
                                 instant_fail=True)
 
     return py_cont

--- a/ciscripts/setup/python/setup.py
+++ b/ciscripts/setup/python/setup.py
@@ -70,7 +70,7 @@ def run(cont, util, shell, argv=None):
                                          "polysquarelint")
                 py_util.pip_install(cont,
                                     util,
-                                    "polysquare-setuptools-lint>=0.0.22")
+                                    "polysquare-setuptools-lint>=0.0.35")
 
         with util.Task("""Installing python test runners"""):
             _install_test_dependencies(cont,

--- a/container-setup.py
+++ b/container-setup.py
@@ -16,7 +16,6 @@ def run(cont, util, shell, argv=None):
 
         cont.fetch_and_import(configure_haskell).run(cont, util, shell, hs_ver)
 
-    cont.fetch_and_import("setup/bii/setup.py").run(cont, util, shell, argv)
     cont.fetch_and_import("setup/conan/setup.py").run(cont, util, shell, argv)
     cont.fetch_and_import("setup/python/setup.py").run(cont, util, shell, argv)
 


### PR DESCRIPTION
These are much lighter. The OS image is still kept around, but packages are installed separately and we just run them without proot.