### PR TITLE
conan: Use python 3 instead of python 2.

### DIFF
--- a/ciscripts/check/conan/check.py
+++ b/ciscripts/check/conan/check.py
@@ -9,12 +9,10 @@ import argparse
 
 import os
 
-from contextlib import contextmanager
-
 
 def _get_python_container(cont, util, shell):
-    """Get a python 2.7.9 installation if necessary."""
-    py_ver = util.language_version("python2")
+    """Get a python 3 installation."""
+    py_ver = util.language_version("python3")
     config_python = "setup/project/configure_python.py"
     return cont.fetch_and_import(config_python).get(cont,
                                                     util,
@@ -31,16 +29,6 @@ def _get_conan_container(cont, util, shell):
 _CONAN_LAYOUT = [
     "build"
 ]
-
-
-@contextmanager
-def _maybe_activate_python(py_cont, util):
-    """Activate py_cont if it exists."""
-    if py_cont:
-        with py_cont.activated(util):
-            yield
-    else:
-        yield
 
 
 def run(cont, util, shell, argv=None, override_kwargs=None):
@@ -60,7 +48,7 @@ def run(cont, util, shell, argv=None, override_kwargs=None):
 
     def _after_lint(cont, os_cont, util):
         """Perform conan specific setup."""
-        with _maybe_activate_python(py_cont, util), conan_cont.activated(util):
+        with py_cont.activated(util), conan_cont.activated(util):
             with util.Task("""Downloading dependencies"""):
                 os_cont.execute(cont,
                                 util.running_output,

--- a/ciscripts/deploy/conan/deploy.py
+++ b/ciscripts/deploy/conan/deploy.py
@@ -20,23 +20,13 @@ except ImportError:
 
 
 def _get_python_container(cont, util, shell):
-    """Get a python 2.7.9 installation if necessary."""
-    py_ver = util.language_version("python2")
+    """Get a python 3 installation."""
+    py_ver = util.language_version("python3")
     config_python = "setup/project/configure_python.py"
     return cont.fetch_and_import(config_python).get(cont,
                                                     util,
                                                     shell,
                                                     py_ver)
-
-
-@contextmanager
-def _maybe_activate_python(py_cont, util):
-    """Activate py_cont if it exists."""
-    if py_cont:
-        with py_cont.activated(util):
-            yield
-    else:
-        yield
 
 
 def updated_dict(input_dict, update):
@@ -120,8 +110,7 @@ def run(cont, util, shell, argv=None):
                                                           ["--bump-version-on",
                                                            "conanfile.py"])
 
-    with _maybe_activate_python(_get_python_container(cont, util, shell),
-                                util):
+    with _get_python_container(cont, util, shell).activated(util):
         with captured_messages(util) as version_stream:
             util.execute(cont,
                          util.running_output,


### PR DESCRIPTION
Conan 0.9.0 is now compatible with python 3 and was recently
released.